### PR TITLE
Adds CLI-configurable column name decorators for TypeOrm decorators: …

### DIFF
--- a/src/IGenerationOptions.ts
+++ b/src/IGenerationOptions.ts
@@ -23,6 +23,10 @@ export default interface IGenerationOptions {
     skipSchema: boolean;
     indexFile: boolean;
     exportType: "named" | "default";
+    createDateColumns: string[];
+    updateDateColumns: string[];
+    deleteDateColumns: string[];
+    versionColumns: string[];
 }
 
 export const eolConverter = {
@@ -49,6 +53,10 @@ export function getDefaultGenerationOptions(): IGenerationOptions {
         skipSchema: false,
         indexFile: false,
         exportType: "named",
+        createDateColumns: [],
+        updateDateColumns: [],
+        deleteDateColumns: [],
+        versionColumns: []
     };
     return generationOptions;
 }

--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -79,6 +79,7 @@ export default function modelCustomizationPhase(
     namingStrategy.enablePluralization(generationOptions.pluralizeNames);
     let retVal = removeIndicesGeneratedByTypeorm(dbModel);
     retVal = removeColumnsInRelation(dbModel);
+    retVal = setDecoratorPrefix( retVal, generationOptions );
     retVal = applyNamingStrategy(namingStrategy, dbModel);
     retVal = addImportsAndGenerationOptions(retVal, generationOptions);
     retVal = removeColumnDefaultProperties(retVal, defaultValues);
@@ -128,6 +129,41 @@ function removeIndicesGeneratedByTypeorm(dbModel: Entity[]): Entity[] {
     });
     return dbModel;
 }
+
+function setDecoratorPrefix(dbModel: Entity[], generationOptions : IGenerationOptions): Entity[] {
+    dbModel.forEach((entity) => {
+        entity.columns.forEach((column) => {
+            generationOptions.deleteDateColumns.forEach((name) => {
+                if (column.options.name === name) {
+                    column.decoratorPrefix = "DeleteDate";
+                }
+            });
+            generationOptions.updateDateColumns.forEach((name) => {
+                if (column.options.name === name) {
+                    column.decoratorPrefix = "UpdateDate";
+                }
+            });
+            generationOptions.createDateColumns.forEach((name) => {
+                if (column.options.name === name) {
+                    column.decoratorPrefix = "CreateDate";
+                }
+            });
+            generationOptions.versionColumns.forEach((name) => {
+                if (column.options.name === name) {
+                    column.decoratorPrefix = "Version";
+                }
+            });
+            // Generated logic is no longer representative of how the decorator gets prefixed in the template
+            if (column.generated) {
+                column.decoratorPrefix = "PrimaryGenerated";
+            }
+        });
+    });
+    return dbModel;
+
+}
+
+
 function removeColumnsInRelation(dbModel: Entity[]): Entity[] {
     dbModel.forEach((entity) => {
         entity.columns = entity.columns.filter(

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import IConnectionOptions, {
 import IGenerationOptions, {
     getDefaultGenerationOptions,
 } from "./IGenerationOptions";
-
 import fs = require("fs-extra");
 import inquirer = require("inquirer");
 import path = require("path");
@@ -285,6 +284,31 @@ function checkYargsParameters(options: options): options {
             default: options.generationOptions.exportType === "default",
             describe: "Generate index file",
         },
+
+        deleteDateColumn: {
+            string: true,
+            default: options.generationOptions.deleteDateColumns.join(","),
+            describe:
+                "Apply @DeleteDateColumn decorator to columns with this name",
+        },
+        updateDateColumn: {
+            string: true,
+            default: options.generationOptions.updateDateColumns.join(","),
+            describe:
+                "Apply @DpdateDateColumn decorator to columns with this name",
+        },
+        createDateColumn: {
+            string: true,
+            default: options.generationOptions.createDateColumns.join(","),
+            describe:
+                "Apply @CreateDateColumn decorator to columns with this name",
+        },
+        versionColumn: {
+            string: true,
+            default: options.generationOptions.versionColumns.join(","),
+            describe:
+                "Apply @VersionColumn decorator to columns with this name",
+        },
     });
 
     options.connectionOptions.databaseName = argv.d;
@@ -325,6 +349,33 @@ function checkYargsParameters(options: options): options {
     options.generationOptions.exportType = argv.defaultExport
         ? "default"
         : "named";
+
+    let deleteDateColumn = argv.deleteDateColumn.split(",");
+    if (deleteDateColumn.length === 1 && deleteDateColumn[0] === "") {
+        deleteDateColumn = [];
+    }
+    options.generationOptions.deleteDateColumns = deleteDateColumn;
+
+    let updateDateColumn = argv.updateDateColumn.split(",");
+    if (updateDateColumn.length === 1 && updateDateColumn[0] === "") {
+        updateDateColumn = [];
+    }
+    options.generationOptions.updateDateColumns = updateDateColumn;
+
+    let createDateColumn = argv.createDateColumn.split(",");
+    if (createDateColumn.length === 1 && createDateColumn[0] === "") {
+        createDateColumn = [];
+    }
+    options.generationOptions.createDateColumns = createDateColumn;
+
+    let versionColumn = argv.versionColumn.split(",");
+    if (versionColumn.length === 1 && versionColumn[0] === "") {
+        versionColumn = [];
+    }
+    options.generationOptions.versionColumns = versionColumn;
+    
+
+
 
     return options;
 }

--- a/src/models/Column.ts
+++ b/src/models/Column.ts
@@ -23,4 +23,6 @@ export type Column = {
         array?: boolean; // ?
         comment?: string;
     };
+
+    decoratorPrefix?: string;
 };

--- a/src/templates/entity.mst
+++ b/src/templates/entity.mst
@@ -1,17 +1,21 @@
 {{#*inline "Index"}}
 @Index("{{name}}",[{{#columns}}"{{toPropertyName .}}",{{/columns~}}],{ {{json options}} })
 {{/inline}}
+
 {{#*inline "Import"}}
 import {{localImport (toEntityName .)}} from './{{toFileName .}}'
 {{/inline}}
+
 {{#*inline "Column"}}
-{{#generated}}@PrimaryGeneratedColumn({ type:"{{type}}", {{/generated}}{{^generated}}@Column("{{type}}",{ {{#primary}}primary:{{primary}},{{/primary}}{{/generated}}{{json options}}{{#default}},default: {{.}},{{/default}} })
+{{#if decoratorPrefix}}@{{decoratorPrefix}}Column({ type:"{{type}}", {{else}}@Column("{{type}}",{ {{#primary}}primary:{{primary}},{{/primary}}{{/if}}{{json options}}{{#default}},default: {{.}},{{/default}} })
 {{printPropertyVisibility}}{{toPropertyName tscName}}{{strictMode}}:{{tscType}}{{#if options.nullable}} | null{{/if}};
 
 {{/inline}}
+
 {{#*inline "JoinColumnOptions"}}
 { name: "{{name}}", referencedColumnName: "{{toPropertyName referencedColumnName}}" },
 {{/inline}}
+
 {{#*inline "Relation"}}
 @{{relationType}}(()=>{{toEntityName relatedTable}},{{toPropertyName relatedTable}}=>{{toPropertyName relatedTable}}.{{toPropertyName relatedField}}{{#if relationOptions}},{ {{json relationOptions}} }{{/if}})
 {{#if joinColumnOptions}}@JoinColumn([{{#joinColumnOptions}}{{> JoinColumnOptions}}{{/joinColumnOptions}}]){{/if}}
@@ -19,17 +23,20 @@ import {{localImport (toEntityName .)}} from './{{toFileName .}}'
 {{printPropertyVisibility}}{{toPropertyName fieldName}}{{strictMode}}:{{toRelation (toEntityName relatedTable) relationType}};
 
 {{/inline}}
+
 {{#*inline "RelationId"}}
 @RelationId(({{toPropertyName entityName}}:{{toEntityName entityName}})=>{{toPropertyName entityName}}.{{toPropertyName relationField}})
 {{printPropertyVisibility}}{{toPropertyName fieldName}}{{strictMode}}:{{fieldType}};
 
 {{/inline}}
+
 {{#*inline "Constructor"}}
 {{printPropertyVisibility}}constructor(init?: Partial<{{toEntityName entityName}}>) {
     {{#activeRecord}}super();
     {{/activeRecord}}Object.assign(this, init);
 }
 {{/inline}}
+
 {{#*inline "Entity"}}
 {{#indices}}{{> Index}}{{/indices~}}
 @Entity("{{sqlName}}"{{#schema}} ,{schema:"{{.}}"{{#if ../database}}, database:"{{../database}}"{{/if}} } {{/schema}})
@@ -41,7 +48,8 @@ export {{defaultExport}} class {{toEntityName tscName}}{{#activeRecord}} extends
 {{#if generateConstructor}}{{>Constructor entityName=tscName}}{{/if~}}
 }
 {{/inline}}
-import {BaseEntity,Column,Entity,Index,JoinColumn,JoinTable,ManyToMany,ManyToOne,OneToMany,OneToOne,PrimaryColumn,PrimaryGeneratedColumn,RelationId} from "typeorm";
+
+import {BaseEntity,Column,Entity,Index,JoinColumn,JoinTable,ManyToMany,ManyToOne,OneToMany,OneToOne,PrimaryColumn,PrimaryGeneratedColumn,CreateDateColumn,UpdateDateColumn,DeleteDateColumn,VersionColumn,RelationId} from "typeorm";
 {{#fileImports}}{{> Import}}{{/fileImports}}
 
 {{> Entity}}


### PR DESCRIPTION
…@DeleteDateColumn, @CreateDateColumn, @VersionColumn, @UpdateDateColumn

Updates Column to know which decoratorPrefix is going to apply to a column.
Updates entity template to render all prefixed decorators (replacing PrimaryGeneratedColumn logic)
Updates IGenerationOptions to capture column names flagged for specific decorators.
Updates index to capture generation options passed via cli.
Adds setDecoratorPrefix method to model customizations to recognize when data matches the requested generation options.